### PR TITLE
Disable Style/TrailingCommaInArrayLiteral by default (#5)

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -115,6 +115,9 @@ Style/Next:
 Style/RescueModifier:
   Enabled: false
 
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
 Style/WhileUntilDo:
   Enabled: false
 


### PR DESCRIPTION
To prevent syntax from being destroyed by auto-correction.

resolve #5 