### PR TITLE
Fix failure to detect Ruby code from nested structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix failure to detect Ruby code from nested structure.
+
 ## 0.17.0 - 2022-03-10
 
 ### Changed

--- a/lib/slimcop/ruby_extractor.rb
+++ b/lib/slimcop/ruby_extractor.rb
@@ -59,12 +59,9 @@ module Slimcop
     def traverse(node, &block)
       return unless node.instance_of?(::Array)
 
-      if node[0] == :slimi && node[1] == :position
-        block.call(node[2], node[3])
-      else
-        node.each do |element|
-          traverse(element, &block)
-        end
+      block.call(node[2], node[3]) if node[0] == :slimi && node[1] == :position
+      node.each do |element|
+        traverse(element, &block)
       end
     end
   end

--- a/spec/slimcop/ruby_extractor_spec.rb
+++ b/spec/slimcop/ruby_extractor_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Slimcop::RubyExtractor do
+  describe '.call' do
+    subject do
+      described_class.call(
+        file_path: file_path,
+        source: source
+      )
+    end
+
+    let(:file_path) do
+      'dummy.slim'
+    end
+
+    let(:source) do
+      <<~SLIM
+        a
+        = b
+        - array.each do |element|
+          = element
+      SLIM
+    end
+
+    context 'with valid condition' do
+      it 'returns an Array of positional code data' do
+        is_expected.to eq(
+          [
+            {
+              code: 'b',
+              offset: 4
+            },
+            {
+              code: 'array.each',
+              offset: 8
+            },
+            {
+              code: 'element',
+              offset: 36
+            }
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
failure case example:

```ruby
- array.each do |element|
  = some_offense_code
```